### PR TITLE
update host url

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /* jshint esversion: 6 */
 const https = require("https");
-const hostUrl = "https://www.xkcd.com/";
+const hostUrl = "https://xkcd.com/";
 const comicPath = "info.0.json";
 
 


### PR DESCRIPTION
using the old www.xkcd.com url returns a 301 moved permanently page instead of json, removing the subdomain fixes it

(not sure what the newline part is about, github did something on their side)